### PR TITLE
docs: corrigida a ordem dos atributos 'Agencia' e 'Numero' na tabela do README.md

### DIFF
--- a/desafios/sintaxe/README.md
+++ b/desafios/sintaxe/README.md
@@ -15,8 +15,8 @@ Vamos exercitar todo o conteúdo apresentado no módulo de Sintaxe codificando o
 
 | Atributo  | Tipo     | Exemplo   
 | --------- | ---------| ------- 
-| Numero    | Inteiro  | 1021 
-| Agencia   | Texto    | 067-8
+| Agencia    | Inteiro  | 1021 
+| Numero   | Texto    | 067-8
 | Nome Cliente | Texto    | MARIO ANDRADE
 | Saldo | Decimal |237.48
 


### PR DESCRIPTION
docs: corrigida a ordem dos atributos 'Agencia' e 'Numero' na tabela do README.md para alinhar com o exemplo de entrada do usuário.